### PR TITLE
chore(ios): upgrade the iOS DocumentDetector dependency to v16.0.3

### DIFF
--- a/document_detector/ios/flutter_caf_document_detector.podspec
+++ b/document_detector/ios/flutter_caf_document_detector.podspec
@@ -21,5 +21,5 @@ A Flutter plugin for Caf.io solution for document detection. It uses advanced co
   s.swift_version = '5.3.2'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'DocumentDetector', '16.0.2'
+  s.dependency 'DocumentDetector', '16.0.3'
 end


### PR DESCRIPTION
## Descrição

- Atualiza a dependência nativa do DocumentDetector no iOS de 16.0.2 para 16.0.3. 
  - Corrige o problema mencionado na #5, onde a mensagem de sucesso de captura não estava localizada.

Referência:
- https://docs.caf.io/caf-sdk/ios/standalone-modules/document-detector/release-notes

| Antes | Agora |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/161a4157-daa0-490c-9ff2-ef23c8c1c199" width=275 /> | <img src="https://github.com/user-attachments/assets/28fff3f4-5d62-4930-b429-ac2aaab6dc67" width=275 /> | 

